### PR TITLE
feat(auth): 로그인 응답에 현재 좌석 locationCode 추가

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/LoginResponseDto.java
@@ -12,5 +12,6 @@ public class LoginResponseDto {
     private String name;
     private String grade;
     private int remainingTime;
-    private String currentSeat;
+    private int averageDecibel;
+    private int noiseOccurrence;
 }

--- a/backend/src/main/java/com/shhtudy/backend/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/LoginResponseDto.java
@@ -12,6 +12,7 @@ public class LoginResponseDto {
     private String name;
     private String grade;
     private int remainingTime;
+    private String currentSeat;
     private int averageDecibel;
     private int noiseOccurrence;
 }

--- a/backend/src/main/java/com/shhtudy/backend/entity/Seat.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/Seat.java
@@ -3,9 +3,6 @@ package com.shhtudy.backend.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Entity
 @Table(name = "seats")
 @Getter
@@ -28,8 +25,4 @@ public class Seat {
         SILENT,
         MY_SEAT
     }
-
-    @OneToMany(mappedBy = "currentSeat")
-    private List<User> users; // 보통 이건 잘 안 씀
-
 }

--- a/backend/src/main/java/com/shhtudy/backend/entity/User.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/User.java
@@ -36,6 +36,10 @@ public class User {
         WARNING, GOOD, SILENT
     }
 
-    private int averageDecibel;
-    private int noiseOccurrence;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_seat_id") // users 테이블에 foreign key 생성
+    private Seat currentSeat;
+
+    private int averageDecibel; //TODO: noise 엔티티 생성 시 추가
+    private int noiseOccurrence;//TODO: noise 엔티티 생성 시 추가
 }

--- a/backend/src/main/java/com/shhtudy/backend/entity/User.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/User.java
@@ -27,7 +27,7 @@ public class User {
 
     private int remainingTime = 0;
 
-    private int points = 0;
+    private int mannerScore = 0;
 
     @Enumerated(EnumType.STRING)     // enum 값을 문자열로 저장
     private Grade grade = Grade.GOOD;
@@ -36,9 +36,6 @@ public class User {
         WARNING, GOOD, SILENT
     }
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "current_seat_id") // 또는 current_user_id가 seats에서 user로 연결된 경우
-    private Seat currentSeat;
-
-
+    private int averageDecibel;
+    private int noiseOccurrence;
 }

--- a/backend/src/main/java/com/shhtudy/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/UserRepository.java
@@ -5,8 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByFirebaseUid(String firebaseUid);
     Optional<User> findByPhoneNumber(String phoneNumber);
-
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/AuthService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/AuthService.java
@@ -42,8 +42,12 @@ public class AuthService {
         response.setAverageDecibel(user.getAverageDecibel());
         response.setNoiseOccurrence(user.getNoiseOccurrence());
 
-        return response;
+        // 현재 좌석 위치가 있으면 locationCode 추가
+        if (user.getCurrentSeat() != null) {
+            response.setCurrentSeat(user.getCurrentSeat().getLocationCode());
+        }
 
+        return response;
     }
 
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/AuthService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/AuthService.java
@@ -39,7 +39,8 @@ public class AuthService {
         response.setName(user.getName());
         response.setGrade(user.getGrade().name());
         response.setRemainingTime(user.getRemainingTime());
-        response.setCurrentSeat(user.getCurrentSeat() != null ? user.getCurrentSeat().getLocationCode() : null);
+        response.setAverageDecibel(user.getAverageDecibel());
+        response.setNoiseOccurrence(user.getNoiseOccurrence());
 
         return response;
 


### PR DESCRIPTION
- 로그인 성공 시 currentSeat가 존재할 경우 해당 좌석의 locationCode를 응답 DTO에 포함
- 프론트엔드는 로그인 직후 currentSeat 값을 저장하여 공통 헤더 조회 최소화 가능
