### PR TITLE
feat(notification): 알림 존재 여부 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/NotificationController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/NotificationController.java
@@ -1,0 +1,32 @@
+package com.shhtudy.backend.controller;
+
+import com.shhtudy.backend.dto.NotificationStatusResponseDto;
+import com.shhtudy.backend.global.response.ApiResponse;
+import com.shhtudy.backend.service.FirebaseAuthService;
+import com.shhtudy.backend.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+
+public class NotificationController {
+    private final NotificationService notificationService;
+    private final FirebaseAuthService firebaseAuthService;
+
+    @GetMapping("/unread-status")
+    public ResponseEntity<ApiResponse<NotificationStatusResponseDto>> getUnreadNotificationStatus(@RequestHeader("Authorization") String authorizationHeader) {
+        String idToken = authorizationHeader.replace("Bearer ", "");
+        String userId = firebaseAuthService.verifyIdToken(idToken);
+
+        NotificationStatusResponseDto response = notificationService.getHasUnreadNotifications(userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "읽지 않은 알림 여부 조회 성공"));
+
+    }
+
+}

--- a/backend/src/main/java/com/shhtudy/backend/dto/NotificationStatusResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/NotificationStatusResponseDto.java
@@ -1,0 +1,10 @@
+package com.shhtudy.backend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotificationStatusResponseDto {
+    private boolean hasUnreadMessages;
+}

--- a/backend/src/main/java/com/shhtudy/backend/entity/Message.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/Message.java
@@ -1,4 +1,31 @@
 package com.shhtudy.backend.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "messages")
 public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long messageId;
+
+    @Column(nullable = false)
+    private String senderId;  // 보낸 사용자 (firebase_uid)
+
+    @Column(nullable = false)
+    private String receiverId; // 받는 사용자 (firebase_uid)
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;  // 메세지 내용
+
+    @Column(nullable = false)
+    private boolean isRead = false;  // 읽음 여부 (기본값 false)
+
+    @Column(nullable = false, updatable = false)
+    private java.time.LocalDateTime sentAt = java.time.LocalDateTime.now();  // 보낸 시각
 }

--- a/backend/src/main/java/com/shhtudy/backend/entity/Notice.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/Notice.java
@@ -1,0 +1,26 @@
+package com.shhtudy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notices")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/com/shhtudy/backend/entity/NoticeRead.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/NoticeRead.java
@@ -1,0 +1,29 @@
+package com.shhtudy.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notice_reads")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeRead {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDateTime readAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/com/shhtudy/backend/repository/MessageRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/MessageRepository.java
@@ -1,0 +1,9 @@
+package com.shhtudy.backend.repository;
+
+import com.shhtudy.backend.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+    boolean existsUnreadMessages(String userId);
+}

--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeReadRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeReadRepository.java
@@ -1,0 +1,13 @@
+package com.shhtudy.backend.repository;
+
+import com.shhtudy.backend.entity.NoticeRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NoticeReadRepository extends JpaRepository<NoticeRead, Long> {
+    @Query("SELECT COUNT(n) > 0 FROM Notice n WHERE n.id NOT IN (" +
+            "SELECT nr.notice.id FROM NoticeRead nr WHERE nr.user.firebaseUid = :userId)")
+    boolean existsUnreadNotices(@Param("userId") String userId);
+
+}

--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package com.shhtudy.backend.repository;
+
+import com.shhtudy.backend.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/backend/src/main/java/com/shhtudy/backend/service/FirebaseAuthService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/FirebaseAuthService.java
@@ -1,0 +1,21 @@
+package com.shhtudy.backend.service;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.shhtudy.backend.exception.CustomException;
+import com.shhtudy.backend.exception.code.ErrorCode;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FirebaseAuthService {
+
+    public String verifyIdToken(String idToken) {
+        try {
+            FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdToken(idToken);
+            return decodedToken.getUid();
+        } catch (FirebaseAuthException e) {
+            throw new CustomException(ErrorCode.INVALID_FIREBASE_TOKEN);
+        }
+    }
+}

--- a/backend/src/main/java/com/shhtudy/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/NotificationService.java
@@ -1,0 +1,25 @@
+package com.shhtudy.backend.service;
+
+import com.shhtudy.backend.dto.NotificationStatusResponseDto;
+import com.shhtudy.backend.repository.MessageRepository;
+import com.shhtudy.backend.repository.NoticeReadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final MessageRepository messageRepository;
+    private final NoticeReadRepository noticeReadRepository;
+
+    public NotificationStatusResponseDto getHasUnreadNotifications(String userId) {
+        boolean hasUnreadMessages = messageRepository.existsUnreadMessages(userId);
+        boolean hasUnreadNotices=noticeReadRepository.existsUnreadNotices(userId);
+
+        NotificationStatusResponseDto response = new NotificationStatusResponseDto();
+        response.setHasUnreadMessages(hasUnreadMessages || hasUnreadNotices);
+
+        return response;
+    }
+}


### PR DESCRIPTION
- 읽지 않은 쪽지 또는 공지가 존재하는지 확인하는 API 구현
- 메시지와 공지 읽음 상태를 OR 연산으로 통합
- 경로: GET /notifications/unread-status
- FirebaseAuthService를 통한 ID 토큰 검증 적용
- 공지/읽음 엔티티 및 Repository(Notice, NoticeRead) 생성