### PR TITLE
feat(user): FirebaseAuthService 공통화 및 SignUp 메서드명 변경

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/UserController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.shhtudy.backend.controller;
 
 import com.shhtudy.backend.dto.SignUpRequestDto;
+import com.shhtudy.backend.service.FirebaseAuthService;
 import com.shhtudy.backend.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,17 +14,18 @@ import org.springframework.web.bind.annotation.*;
 
 public class UserController {
     private final UserService userService;
+    private final FirebaseAuthService firebaseAuthService;
 
     @PostMapping
-    public ResponseEntity<String> SignUp(@RequestBody @Valid SignUpRequestDto request,
+    public ResponseEntity<String> signUp(@RequestBody @Valid SignUpRequestDto request,
                                          @RequestHeader("Authorization") String authorizationHeader) {
-        // "Bearer {token}" → 순수 토큰만 추출
+        // FirebaseAuthService에서 토큰 검증
         String idToken = authorizationHeader.replace("Bearer ", "");
+        String firebaseUid = firebaseAuthService.verifyIdToken(idToken);
 
         // 회원가입 로직 실행
-        userService.signUp(request, idToken);
+        userService.signUp(request, firebaseUid);
 
-        // 성공 메시지 반환
         return ResponseEntity.ok("회원가입 완료!");
 
     }

--- a/backend/src/main/java/com/shhtudy/backend/service/UserService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/UserService.java
@@ -9,48 +9,33 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseAuthException;
-import com.google.firebase.auth.FirebaseToken;
-
-
 @Service
 @RequiredArgsConstructor
 
 public class UserService {
     private final UserRepository userRepository;
 
-    public void signUp(SignUpRequestDto request, String idToken) {
+    public void signUp(SignUpRequestDto request, String firebaseUid) {
 
-        // 1. Firebase ID Token 검증
-        FirebaseToken firebaseToken;
-        try {
-            firebaseToken = FirebaseAuth.getInstance().verifyIdToken(idToken);
-        } catch (FirebaseAuthException e) {
-            throw new CustomException(ErrorCode.INVALID_FIREBASE_TOKEN);
-        }
-
-        String firebaseUid = firebaseToken.getUid();
-
-        // 2. firebaseUid 중복 확인
+        // 1. firebaseUid 중복 확인
         if (userRepository.findByFirebaseUid(firebaseUid).isPresent()) {
             throw new CustomException(ErrorCode.DUPLICATE_USER);
         }
 
-        // 3. 비밀번호 일치 확인
+        // 2. 비밀번호 일치 확인
         if (!request.getPassword().equals(request.getConfirmPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
-        // 4. 사용자 등록
+        // 3. 사용자 등록
         User user = new User();
         user.setFirebaseUid(firebaseUid);
         user.setName(request.getName());
         user.setPhoneNumber(request.getPhoneNumber());
 
+        // 4. 비밀번호 암호화 후 저장
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         user.setPassword(encoder.encode(request.getPassword()));
-        user.setPassword(request.getPassword());
 
         userRepository.save(user);
     }


### PR DESCRIPTION
- Firebase 토큰 검증 로직을 `FirebaseAuthService`로 공통화
- `UserService`에서 Firebase UID 검증 로직을 `FirebaseAuthService` 호출로 변경
- `SignUp` 메서드명을 자바 컨벤션에 맞게 `signUp`으로 변경