### PR TITLE
refactor(alert): 알림 관련 클래스 및 URL 일관성 있게 리네이밍

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/AlertController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/AlertController.java
@@ -1,9 +1,9 @@
 package com.shhtudy.backend.controller;
 
-import com.shhtudy.backend.dto.NotificationStatusResponseDto;
+import com.shhtudy.backend.dto.AlertStatusResponseDto;
 import com.shhtudy.backend.global.response.ApiResponse;
 import com.shhtudy.backend.service.FirebaseAuthService;
-import com.shhtudy.backend.service.NotificationService;
+import com.shhtudy.backend.service.AlertService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,18 +13,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/notifications")
+@RequestMapping("/alerts")
 
-public class NotificationController {
-    private final NotificationService notificationService;
+public class AlertController {
+    private final AlertService alertService;
     private final FirebaseAuthService firebaseAuthService;
 
     @GetMapping("/unread-status")
-    public ResponseEntity<ApiResponse<NotificationStatusResponseDto>> getUnreadNotificationStatus(@RequestHeader("Authorization") String authorizationHeader) {
+    public ResponseEntity<ApiResponse<AlertStatusResponseDto>> getUnreadAlertStatus(@RequestHeader("Authorization") String authorizationHeader) {
         String idToken = authorizationHeader.replace("Bearer ", "");
         String userId = firebaseAuthService.verifyIdToken(idToken);
 
-        NotificationStatusResponseDto response = notificationService.getHasUnreadNotifications(userId);
+        AlertStatusResponseDto response = alertService.getHasUnreadNotifications(userId);
         return ResponseEntity.ok(ApiResponse.success(response, "읽지 않은 알림 여부 조회 성공"));
 
     }

--- a/backend/src/main/java/com/shhtudy/backend/dto/AlertStatusResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/AlertStatusResponseDto.java
@@ -5,6 +5,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class NotificationStatusResponseDto {
+public class AlertStatusResponseDto {
     private boolean hasUnreadMessages;
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/AlertService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/AlertService.java
@@ -1,6 +1,6 @@
 package com.shhtudy.backend.service;
 
-import com.shhtudy.backend.dto.NotificationStatusResponseDto;
+import com.shhtudy.backend.dto.AlertStatusResponseDto;
 import com.shhtudy.backend.repository.MessageRepository;
 import com.shhtudy.backend.repository.NoticeReadRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class NotificationService {
+public class AlertService {
 
     private final MessageRepository messageRepository;
     private final NoticeReadRepository noticeReadRepository;
 
-    public NotificationStatusResponseDto getHasUnreadNotifications(String userId) {
+    public AlertStatusResponseDto getHasUnreadNotifications(String userId) {
         boolean hasUnreadMessages = messageRepository.existsUnreadMessages(userId);
         boolean hasUnreadNotices=noticeReadRepository.existsUnreadNotices(userId);
 
-        NotificationStatusResponseDto response = new NotificationStatusResponseDto();
+        AlertStatusResponseDto response = new AlertStatusResponseDto();
         response.setHasUnreadMessages(hasUnreadMessages || hasUnreadNotices);
 
         return response;


### PR DESCRIPTION
- Notification → Alert 네이밍으로 전면 교체
- AlertController, AlertService, AlertStatusResponseDto 등으로 클래스명 변경
- 요청 URL /notifications → /alerts 로 수정
- 메서드명 getUnreadNotificationStatus → getUnreadAlertStatus 로 변경