### PR TITLE
feat(notice): 공지사항 목록 조회 API 구현 및 읽음 여부 처리 로직 추가

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/NoticeController.java
@@ -1,0 +1,33 @@
+package com.shhtudy.backend.controller;
+
+import com.shhtudy.backend.dto.NoticeResponseDto;
+import com.shhtudy.backend.global.response.ApiResponse;
+import com.shhtudy.backend.service.FirebaseAuthService;
+import com.shhtudy.backend.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notices")
+
+public class NoticeController {
+    private final NoticeService noticeService;
+    private final FirebaseAuthService firebaseAuthService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NoticeResponseDto>>> getNotices(@RequestHeader("Authorization") String authorizationHeader) {
+        String idToken = authorizationHeader.replace("Bearer ", "");
+        String userId = firebaseAuthService.verifyIdToken(idToken);
+
+        List<NoticeResponseDto> response= noticeService.getNoticeWithRaeadStatus(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "공지사항 조회 성공"));
+    }
+}

--- a/backend/src/main/java/com/shhtudy/backend/dto/NoticeResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/NoticeResponseDto.java
@@ -1,0 +1,23 @@
+package com.shhtudy.backend.dto;
+
+import com.shhtudy.backend.entity.Notice;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class NoticeResponseDto {
+    private final Long noticeId;
+    private final String title;
+    private final String content;
+    private final String createdAt;
+    private final boolean isRead;
+
+    public NoticeResponseDto(Notice notice, boolean isRead) {
+        this.noticeId = notice.getId();
+        this.title = notice.getTitle();
+        this.content = notice.getContent();
+        this.createdAt = notice.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        this.isRead = isRead;
+    }
+}

--- a/backend/src/main/java/com/shhtudy/backend/entity/Notice.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/Notice.java
@@ -22,5 +22,11 @@ public class Notice {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
 }

--- a/backend/src/main/java/com/shhtudy/backend/entity/NoticeRead.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/NoticeRead.java
@@ -25,5 +25,10 @@ public class NoticeRead {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private LocalDateTime readAt = LocalDateTime.now();
+    private LocalDateTime readAt;
+
+    @PrePersist
+    protected void prePersist() {
+        this.readAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeReadRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeReadRepository.java
@@ -1,13 +1,17 @@
 package com.shhtudy.backend.repository;
 
 import com.shhtudy.backend.entity.NoticeRead;
+import com.shhtudy.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NoticeReadRepository extends JpaRepository<NoticeRead, Long> {
     @Query("SELECT COUNT(n) > 0 FROM Notice n WHERE n.id NOT IN (" +
             "SELECT nr.notice.id FROM NoticeRead nr WHERE nr.user.firebaseUid = :userId)")
     boolean existsUnreadNotices(@Param("userId") String userId);
 
+    List<NoticeRead> findAllByUser(User user);
 }

--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
@@ -3,5 +3,8 @@ package com.shhtudy.backend.repository;
 import com.shhtudy.backend.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findAllByOrderByCreatedAtDesc();
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/NoticeService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/NoticeService.java
@@ -1,0 +1,48 @@
+package com.shhtudy.backend.service;
+
+import com.shhtudy.backend.dto.NoticeResponseDto;
+import com.shhtudy.backend.entity.Notice;
+import com.shhtudy.backend.entity.NoticeRead;
+import com.shhtudy.backend.entity.User;
+import com.shhtudy.backend.exception.CustomException;
+import com.shhtudy.backend.exception.code.ErrorCode;
+import com.shhtudy.backend.repository.NoticeReadRepository;
+import com.shhtudy.backend.repository.NoticeRepository;
+import com.shhtudy.backend.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+    private final NoticeReadRepository noticeReadRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly=true)
+    public List<NoticeResponseDto> getNoticeWithRaeadStatus(String userId) {
+        User user = userRepository.findById(userId).
+                orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Notice> notices = noticeRepository.findAllByOrderByCreatedAtDesc();
+
+        List<NoticeRead> reads = noticeReadRepository.findAllByUser(user);
+        //사용자가 읽은 공지 ID 목록
+        Set<Long> readNoticeIds = reads.stream()
+                .map(nr -> nr.getNotice().getId())
+                .collect(Collectors.toSet());
+
+        //공지사항 리스트를 dto로 변환하면서 읽음 여부 판단
+        return notices.stream()
+                .map(notice -> new NoticeResponseDto(
+                        notice,
+                        readNoticeIds.contains(notice.getId())
+                ))
+                .toList();
+    }
+}


### PR DESCRIPTION
- 사용자 인증(Firebase ID 토큰) 기반 공지 조회 기능 구현
- 사용자가 읽은 공지사항은 isRead: true로 응답
- NoticeController, NoticeService, NoticeResponseDto 작성 완료