### PR TITLE
feat(notice): 공지사항 읽음 처리 API 구현

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/NoticeController.java
@@ -6,10 +6,7 @@ import com.shhtudy.backend.service.FirebaseAuthService;
 import com.shhtudy.backend.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,5 +26,18 @@ public class NoticeController {
         List<NoticeResponseDto> response= noticeService.getNoticeWithRaeadStatus(userId);
 
         return ResponseEntity.ok(ApiResponse.success(response, "공지사항 조회 성공"));
+    }
+
+    @PostMapping("/{noticeId}/read")
+    public ResponseEntity<ApiResponse<Void>> readNotice(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable Long noticeId
+    ){
+        String idToken = authorizationHeader.replace("Bearer ", "");
+        String userId = firebaseAuthService.verifyIdToken(idToken);
+
+        noticeService.markAsRead(userId, noticeId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "읽음 처리 완료"));
     }
 }

--- a/backend/src/main/java/com/shhtudy/backend/exception/code/ErrorCode.java
+++ b/backend/src/main/java/com/shhtudy/backend/exception/code/ErrorCode.java
@@ -18,6 +18,10 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(-1004, "전화번호 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_FIREBASE_TOKEN(-1005, "유효하지 않은 Firebase 토큰입니다.", HttpStatus.UNAUTHORIZED),
 
+    //공지사항 관련 오류(-4000~-4999)
+    NOTICE_NOT_FOUND(-4001,"해당 ID의 공지사항이 존재하지 않음", HttpStatus.NOT_FOUND),
+    ALREADY_READ(-4002,"이미 읽은 공지사항임 (중복 등록 방지)", HttpStatus.CONFLICT),
+
     // 시스템 오류 (-9000 이상)
     INTERNAL_ERROR(-9001, "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeReadRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeReadRepository.java
@@ -1,5 +1,6 @@
 package com.shhtudy.backend.repository;
 
+import com.shhtudy.backend.entity.Notice;
 import com.shhtudy.backend.entity.NoticeRead;
 import com.shhtudy.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,6 @@ public interface NoticeReadRepository extends JpaRepository<NoticeRead, Long> {
     boolean existsUnreadNotices(@Param("userId") String userId);
 
     List<NoticeRead> findAllByUser(User user);
+
+    boolean existsByUserAndNotice(User user, Notice notice);
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/NoticeService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/NoticeService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,5 +45,30 @@ public class NoticeService {
                         readNoticeIds.contains(notice.getId())
                 ))
                 .toList();
+    }
+
+    @Transactional
+    public void markAsRead(String userId, Long noticeId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 공지사항 존재 여부 확인
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTICE_NOT_FOUND));
+
+        // 3. 이미 읽었는지 체크
+        boolean alreadyRead = noticeReadRepository.existsByUserAndNotice(user, notice);
+        if (alreadyRead) {
+            throw new CustomException(ErrorCode.ALREADY_READ);
+        }
+
+        // 4. 읽음 기록 저장
+        NoticeRead noticeRead = new NoticeRead();
+        noticeRead.setUser(user);
+        noticeRead.setNotice(notice);
+        noticeRead.setReadAt(LocalDateTime.now());
+
+        noticeReadRepository.save(noticeRead);
     }
 }


### PR DESCRIPTION
- POST /notices/{noticeId}/read 엔드포인트 추가
- Firebase 토큰 기반 사용자 인증 및 읽음 기록 저장
- 중복 읽음 요청 시 ALREADY_READ 예외 반환
- ErrorCode: NOTICE_NOT_FOUND(-4001), ALREADY_READ(-4002) 정의