### PR TITLE
feat(message): 쪽지 목록 조회 API 구현 및 닉네임 중복 검증, Swagger 인증 설정 추가

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/shhtudy/backend/config/SwaggerConfig.java
@@ -1,0 +1,14 @@
+package com.shhtudy.backend.config;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+@Configuration
+@SecurityScheme(
+        name = "FirebaseToken",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+}

--- a/backend/src/main/java/com/shhtudy/backend/controller/MessageController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/MessageController.java
@@ -1,0 +1,41 @@
+package com.shhtudy.backend.controller;
+
+import com.shhtudy.backend.dto.MessageListResponseDto;
+import com.shhtudy.backend.global.response.ApiResponse;
+import com.shhtudy.backend.service.FirebaseAuthService;
+import com.shhtudy.backend.service.MessageService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/messages")
+@SecurityRequirement(name = "FirebaseToken")
+@Tag(name = "Message", description = "쪽지 관련 API")
+
+public class MessageController {
+    private final MessageService messageService;
+    private final FirebaseAuthService firebaseAuthService;
+
+    @Operation(summary = "쪽지 목록 조회", description = "받은 쪽지, 보낸 쪽지, 전체 쪽지를 type 파라미터로 구분하여 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MessageListResponseDto>>> getMessages(
+            @Parameter(description = "Firebase 인증 토큰", required = true)
+            @RequestHeader("Authorization") String authorizationHeader,
+
+            @Parameter(description = "조회 타입 (received, sent, all). 기본값은 all")
+            @RequestParam(defaultValue = "all") String type){
+        String idToken = authorizationHeader.replace("Bearer ", "");
+        String firebaseUid = firebaseAuthService.verifyIdToken(idToken);
+
+        List<MessageListResponseDto> response = messageService.getMessageList(firebaseUid, type);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "메시지 조회 성공"));
+    }
+}

--- a/backend/src/main/java/com/shhtudy/backend/controller/UserController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/UserController.java
@@ -4,6 +4,7 @@ import com.shhtudy.backend.dto.SignUpRequestDto;
 import com.shhtudy.backend.global.response.ApiResponse;
 import com.shhtudy.backend.service.FirebaseAuthService;
 import com.shhtudy.backend.service.UserService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
+@SecurityRequirement(name = "FirebaseToken")
 
 public class UserController {
     private final UserService userService;
@@ -31,4 +33,12 @@ public class UserController {
                 new ApiResponse<>(true, "회원가입 완료!", null)
         );
     }
+
+    @GetMapping("/me")
+    public ApiResponse<String> getMyUid(@RequestHeader("Authorization") String authorizationHeader) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        String uid = firebaseAuthService.verifyIdToken(token);
+        return ApiResponse.success(uid, "현재 로그인한 UID");
+    }
+
 }

--- a/backend/src/main/java/com/shhtudy/backend/dto/MessageListResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/MessageListResponseDto.java
@@ -1,0 +1,39 @@
+package com.shhtudy.backend.dto;
+
+import com.shhtudy.backend.entity.Message;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@AllArgsConstructor
+public class MessageListResponseDto {
+    private Long id;
+    private String counterpartDisplayName; // 예: "A-3번 (123)" or "퇴실한 사용자 (123)"
+    private String contentPreview;  // 앞 30자 미리보기
+    private boolean isRead;
+    private String sentAt;
+    private boolean isSentByMe;
+
+    public static MessageListResponseDto from(Message msg, String displayName, boolean isSentByMe) {
+        return new MessageListResponseDto(
+                msg.getMessageId(),
+                displayName,
+                preview(msg.getContent()),
+                msg.isRead(),
+                formatDateTime(msg.getSentAt()),
+                isSentByMe
+        );
+    }
+
+    private static String preview(String content) {
+        return content.length() > 30 ? content.substring(0, 30) + "..." : content;
+    }
+
+    private static String formatDateTime(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+        return dateTime.format(formatter);
+    }
+}

--- a/backend/src/main/java/com/shhtudy/backend/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/dto/SignUpRequestDto.java
@@ -12,6 +12,9 @@ public class SignUpRequestDto {
     @NotBlank(message = "이름은 필수입니다.")
     private String name;
 
+    @Size(min=2, message = "닉네임은 필수입니다.")
+    private String nickname;
+
     @NotBlank(message = "전화번호는 필수입니다.")
     private String phoneNumber;
 

--- a/backend/src/main/java/com/shhtudy/backend/entity/Message.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/Message.java
@@ -4,21 +4,29 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "messages")
+@Table(
+        name = "messages",
+        indexes = {
+                @Index(name = "idx_sender_id", columnList = "sender_id"),
+                @Index(name = "idx_receiver_id", columnList = "receiver_id")
+        }
+)
 public class Message {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messageId;
 
-    @Column(nullable = false)
-    private String senderId;  // 보낸 사용자 (firebase_uid)
+    @Column(name = "sender_id", nullable = false)
+    private String senderId;
 
-    @Column(nullable = false)
-    private String receiverId; // 받는 사용자 (firebase_uid)
+    @Column(name = "receiver_id", nullable = false)
+    private String receiverId;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;  // 메세지 내용
@@ -27,5 +35,10 @@ public class Message {
     private boolean isRead = false;  // 읽음 여부 (기본값 false)
 
     @Column(nullable = false, updatable = false)
-    private java.time.LocalDateTime sentAt = java.time.LocalDateTime.now();  // 보낸 시각
+    private LocalDateTime sentAt;
+
+    @PrePersist
+    protected void prePersist() {
+        this.sentAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/shhtudy/backend/entity/User.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/User.java
@@ -17,6 +17,9 @@ public class User {
 
     private String name;
 
+    @Column(name = "nickname", nullable = false, unique = true)
+    private String nickname;
+
     @Column(unique = true)
     private String phoneNumber;
 
@@ -27,9 +30,7 @@ public class User {
 
     private int remainingTime = 0;
 
-    private int mannerScore = 0;
-    
-    private int points = 0; // 사용자 포인트 (기본값 0)
+    private int mannerScore = 150;
 
     @Enumerated(EnumType.STRING)     // enum 값을 문자열로 저장
     @Column(columnDefinition = "VARCHAR(10)")  // 명시적으로 컬럼 타입과 길이 지정

--- a/backend/src/main/java/com/shhtudy/backend/exception/code/ErrorCode.java
+++ b/backend/src/main/java/com/shhtudy/backend/exception/code/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(-1003, "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_CREDENTIALS(-1004, "전화번호 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_FIREBASE_TOKEN(-1005, "유효하지 않은 Firebase 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    DUPLICATE_NICKNAME(-1006,"이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
 
     //공지사항 관련 오류(-4000~-4999)
     NOTICE_NOT_FOUND(-4001,"해당 ID의 공지사항이 존재하지 않음", HttpStatus.NOT_FOUND),

--- a/backend/src/main/java/com/shhtudy/backend/repository/MessageRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/MessageRepository.java
@@ -2,8 +2,8 @@ package com.shhtudy.backend.repository;
 
 import com.shhtudy.backend.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
     // 사용자가 수신한 읽지 않은 메시지가 존재하는지 확인 (메시지 기능 구현 시 주석 해제 필요)
@@ -11,4 +11,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     @Query("SELECT COUNT(m) > 0 FROM Message m WHERE m.receiverId = :userId AND m.isRead = false")
     boolean existsByReceiverIdAndIsReadFalse(@Param("userId") String userId);
     */
+    List<Message> findByReceiverIdOrderBySentAtDesc(String receiverId);
+    List<Message> findBySenderIdOrderBySentAtDesc(String senderId);
+    List<Message> findBySenderIdOrReceiverIdOrderBySentAtDesc(String senderId, String receiverId);
 }

--- a/backend/src/main/java/com/shhtudy/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByFirebaseUid(String firebaseUid);
     Optional<User> findByPhoneNumber(String phoneNumber);
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/FirebaseAuthService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/FirebaseAuthService.java
@@ -31,6 +31,7 @@ public class FirebaseAuthService {
                 
                 // 개발 모드에서는 항상 성공 처리하고 테스트용 사용자 ID 반환
                 String devUserId = "dev-user-" + System.currentTimeMillis();
+                //String devUserId = "dev-user";
                 System.out.println("개발 모드: 임시 사용자 ID 생성: " + devUserId);
                 return devUserId;
             }

--- a/backend/src/main/java/com/shhtudy/backend/service/MessageService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/MessageService.java
@@ -1,0 +1,57 @@
+package com.shhtudy.backend.service;
+
+import com.shhtudy.backend.dto.MessageListResponseDto;
+import com.shhtudy.backend.entity.Message;
+import com.shhtudy.backend.entity.Seat;
+import com.shhtudy.backend.entity.User;
+import com.shhtudy.backend.exception.CustomException;
+import com.shhtudy.backend.exception.code.ErrorCode;
+import com.shhtudy.backend.repository.MessageRepository;
+import com.shhtudy.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+
+    public List<MessageListResponseDto> getMessageList(String firebaseUid, String type) {
+        // 1. type에 따라 받은/보낸/전체 쪽지 목록 조회
+        List<Message> messages = switch (type) {
+            case "received" -> messageRepository.findByReceiverIdOrderBySentAtDesc(firebaseUid);
+            case "sent"     -> messageRepository.findBySenderIdOrderBySentAtDesc(firebaseUid);
+            default         -> messageRepository.findBySenderIdOrReceiverIdOrderBySentAtDesc(firebaseUid,firebaseUid);
+        };
+
+        // 2. 각 메시지를 DTO로 변환
+        return messages.stream().map(message -> {
+            boolean isSentByMe = message.getSenderId().equals(firebaseUid);
+            String counterpartUid = isSentByMe ? message.getReceiverId() : message.getSenderId();
+
+            // 닉네임 조회
+            String nickname = userRepository.findByFirebaseUid(counterpartUid)
+                    .map(User::getNickname)
+                    .orElse("(알 수 없음)");
+
+            // 좌석 상태 조회
+            // 먼저 상대방 유저를 가져온 뒤
+            User counterpart = userRepository.findByFirebaseUid(counterpartUid)
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+            // 상대방의 현재 좌석을 가져온다
+            Seat seat = counterpart.getCurrentSeat();
+
+            String displayName = seat != null
+                    ? seat.getLocationCode() + "번 (" + nickname + ")"
+                    : "퇴실한 사용자 (" + nickname + ")";
+
+
+            return MessageListResponseDto.from(message, displayName, isSentByMe);
+        }).toList();
+    }
+
+}

--- a/backend/src/main/java/com/shhtudy/backend/service/UserService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/UserService.java
@@ -37,6 +37,11 @@ public class UserService {
                 throw new CustomException(ErrorCode.DUPLICATE_USER);
             }
 
+            if (userRepository.existsByNickname(request.getNickname())) {
+                logger.warn("회원가입 실패 - 이미 존재하는 닉네임: {}", request.getNickname());
+                throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+            }
+
             // 2. 비밀번호 일치 확인
             if (!request.getPassword().equals(request.getConfirmPassword())) {
                 logger.warn("회원가입 실패 - 비밀번호 불일치");
@@ -47,6 +52,7 @@ public class UserService {
             User user = new User();
             user.setFirebaseUid(firebaseUid);
             user.setName(request.getName());
+            user.setNickname(request.getNickname());
             user.setPhoneNumber(request.getPhoneNumber());
 
             // 4. 비밀번호 암호화 후 저장

--- a/backend/src/main/java/com/shhtudy/backend/util/PasswordGenerator.java
+++ b/backend/src/main/java/com/shhtudy/backend/util/PasswordGenerator.java
@@ -5,7 +5,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class PasswordGenerator {
     public static void main(String[] args) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        String rawPassword = "testpassword";
+        String rawPassword = "444444";
         String encodedPassword = encoder.encode(rawPassword);
         System.out.println("암호화된 비밀번호: " + encodedPassword);
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -43,3 +43,7 @@ logging.level.com.shhtudy.backend=DEBUG
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.transaction=DEBUG
+
+# Swagger 문서 경로 설정
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
- /messages?type=all|received|sent API 구현 · 수신/발신/통합 탭별 필터링 및 응답 DTO 구성 · 좌석 상태 + 닉네임 병기 방식의 displayName 로직 포함

- message 엔티티 및 레포지토리, 서비스 계층 로직 개발

- 사용자 닉네임(nickname) 필드 추가 및 회원가입 시 중복 검증 로직 적용 · DB에 unique 제약 조건 반영 · 중복 시 CustomException 발생

- 개발 환경에서 Firebase 인증 우회 설정 (`dev-user` UID 고정) · 매 요청마다 UID가 달라지는 문제 해결 · /users/me API로 현재 로그인 UID 확인 가능

- Swagger 설정 적용 · @SecurityScheme, @SecurityRequirement로 Bearer 인증 연동 · Authorize 버튼을 통해 자동 헤더 삽입 가능