### PR TITLE
refactor(message): 쪽지 기능에 소프트 삭제 로직 적용

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/MessageController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/MessageController.java
@@ -79,16 +79,16 @@ public class MessageController {
         return ResponseEntity.ok(ApiResponse.success(count, "조회 성공"));
     }
 
-/*
-    @Operation(summary = "쪽지 삭제", description = "특정 쪽지를 삭제합니다.")
-    @DeleteMapping("/{messagesId}")
+    @Operation(summary = "쪽지 삭제", description = "자신이 받은 또는 보낸 쪽지를 삭제합니다. 양측 모두 삭제 시 실제 삭제됩니다.")
+    @DeleteMapping("/{messageId}")
     public ResponseEntity<ApiResponse<String>> deleteMessage(
             @RequestHeader("Authorization") String authorizationHeader,
-            @PathVariable Long messagesId
+            @PathVariable Long messageId
     ) {
-        String idToken = authorizationHeader.replace("Bearer ", "");
-        String firebaseUid = firebaseAuthService.verifyIdToken(idToken);
+        String firebaseUid = firebaseAuthService.verifyIdToken(authorizationHeader.replace("Bearer ", ""));
+        messageService.deleteMessage(firebaseUid, messageId);
+        return ResponseEntity.ok(ApiResponse.success(null, "삭제 완료"));
     }
- */
+
 }
 

--- a/backend/src/main/java/com/shhtudy/backend/entity/Message.java
+++ b/backend/src/main/java/com/shhtudy/backend/entity/Message.java
@@ -39,6 +39,12 @@ public class Message {
     @Column(nullable = false, updatable = false)
     private LocalDateTime sentAt;
 
+    @Column(nullable = false)
+    private boolean deletedBySender = false;
+
+    @Column(nullable = false)
+    private boolean deletedByReceiver = false;
+
     @PrePersist
     protected void prePersist() {
         this.sentAt = LocalDateTime.now();

--- a/backend/src/main/java/com/shhtudy/backend/exception/code/ErrorCode.java
+++ b/backend/src/main/java/com/shhtudy/backend/exception/code/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     //메시지 관련 오류(-2000~-2999)
     MESSAGE_NOT_FOUND(-2001,"존재하지 않는 메시지 입니다." ,HttpStatus.NOT_FOUND ),
+    FORBIDDEN(-2002, "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 
     //공지사항 관련 오류(-4000~-4999)
     NOTICE_NOT_FOUND(-4001,"해당 ID의 공지사항이 존재하지 않음", HttpStatus.NOT_FOUND),

--- a/backend/src/main/java/com/shhtudy/backend/repository/MessageRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/MessageRepository.java
@@ -4,10 +4,19 @@ import com.shhtudy.backend.entity.Message;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    long countByReceiverIdAndReadFalse(String receiverId);
-    Page<Message> findByReceiverId(String receiverId, Pageable pageable);
-    Page<Message> findBySenderId(String senderId, Pageable pageable);
-    Page<Message> findBySenderIdOrReceiverId(String senderId, String receiverId, Pageable pageable);
+    long countByReceiverIdAndReadFalseAndDeletedByReceiverFalse(String receiverId);
+    Page<Message> findByReceiverIdAndDeletedByReceiverFalse(String receiverId, Pageable pageable);
+    Page<Message> findBySenderIdAndDeletedBySenderFalse(String senderId, Pageable pageable);
+    @Query("""
+        SELECT m FROM Message m
+        WHERE
+            (m.senderId = :uid AND m.deletedBySender = false)
+            OR
+            (m.receiverId = :uid AND m.deletedByReceiver = false)
+    """)
+    Page<Message> findAllVisibleMessages(@Param("uid") String uid, Pageable pageable);
 }


### PR DESCRIPTION
쪽지 메시지에 대해 soft deletion을 지원하도록 리팩터링했습니다.
`deletedBySender`, `deletedByReceiver` 필드를 추가하고, Repository 쿼리 및 Service 로직을 수정하여 사용자 기준 삭제 처리를 수행합니다.
발신자와 수신자 모두 삭제한 경우에만 실제 DB에서 영구 삭제됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability for users to delete messages from their own inbox or sent folder. Messages are only permanently deleted when both sender and receiver have deleted them.
- **Bug Fixes**
	- Improved message visibility so that deleted messages no longer appear in the sender's or receiver's message lists.
- **Other Improvements**
	- Enhanced error handling with clearer access control messages for unauthorized deletion attempts.
	- Updated message counts and retrieval to accurately reflect deleted messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->