### PR TITLE
feat: 쪽지 목록 조회 시 읽지 않은 메시지 자동 읽음 처리 (#28)

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/MessageController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/MessageController.java
@@ -29,7 +29,7 @@ public class MessageController {
     private final MessageService messageService;
     private final FirebaseAuthService firebaseAuthService;
 
-    @Operation(summary = "쪽지 목록 조회", description = "받은/보낸/전체 쪽지를 조회합니다.")
+    @Operation(summary = "쪽지 목록 조회", description = "받은/보낸/전체 쪽지를 조회합니다.\n 받은 메시지에 한해서 모두 읽음 처리합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<MessageListResponseDto>>> getAllMessages(
             @RequestHeader("Authorization") String authorizationHeader,


### PR DESCRIPTION
## ✨ 요약
쪽지 목록을 조회할 때, 받은 쪽지 중 읽지 않은 메시지를 모두 읽음 처리하는 기능을 추가했습니다.

## ✅ 작업 내용
- [ ] API 구현
- [ ] 스웨거 수정

## 📚 참고 자료


## 🔎 관련 이슈
Closes #28 
