### PR TITLE
feat: 마이페이지용 읽지 않은 공지 요약 조회 기능 추가 (#30)

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/shhtudy/backend/controller/NoticeController.java
@@ -16,6 +16,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notices")
@@ -52,6 +54,22 @@ public class NoticeController {
         NoticeResponseDto response = noticeService.getNoticeDetail(noticeId, userId);
 
         return ResponseEntity.ok(ApiResponse.success(response, "공지 상세 조회 성공"));
+    }
+
+    @Operation(summary = "마이페이지 공지 요약 조회", description = "읽지 않은 공지를 최신순으로 최대 2건 조회합니다.")
+    @GetMapping("/mypage")
+    public ResponseEntity<ApiResponse<List<NoticeSummaryResponseDto>>> getMessageSummaryForMyPage(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String firebaseUid = firebaseAuthService.verifyIdToken(authorizationHeader.replace("Bearer ", ""));
+
+        List<NoticeSummaryResponseDto> result = noticeService.getUnreadNoticeForMyPage(firebaseUid);
+
+        if (result.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.success(result, "읽지 않은 공지가 없습니다."));
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(result, "마이페이지 공지 요약 조회 성공"));
     }
 
 }

--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
@@ -4,7 +4,21 @@ import com.shhtudy.backend.entity.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Page<Notice> findAll(Pageable pageable);
+    @Query("""
+    SELECT n FROM Notice n
+    WHERE n.id NOT IN (
+        SELECT nr.notice.id FROM NoticeRead nr WHERE nr.userId = :userId
+    )
+    ORDER BY n.createdAt DESC
+""")
+    List<Notice> findTop2UnreadByUserId(@Param("userId") String userId, Pageable pageable);
+
+
 }


### PR DESCRIPTION
## ✨ 요약
마이페이지 진입 시, 사용자가 읽지 않은 공지를 최신순으로 최대 2건 조회할 수 있는 API를 추가했습니다.

## ✅ 작업 내용
- `/notices/mypage` GET API 추가
- 읽지 않은 공지를 기준으로 최신순 정렬 및 최대 2건 조회
- 읽음 여부는 `NoticeRead` 테이블을 기준으로 판단
- Page 대신 List 형태로 반환 (페이징 불필요)
- Swagger 문서 설명 추가


## 📚 참고 자료
[https://www.notion.so/Page-1ffc9713758180f5b5e7d5c642c138c2?pvs=4](url)

## 🔎 관련 이슈
Closes #30 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to display up to two unread notices on the user's "My Page" for quick access to recent updates.

- **Refactor**
  - Updated user identification throughout the notice system to consistently use Firebase UID, improving integration with authentication services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->