### PR TITLE
[refactor] findTop2UnreadByUserId 메서드 이름 정리 (#32)

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/repository/NoticeRepository.java
@@ -18,7 +18,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     )
     ORDER BY n.createdAt DESC
 """)
-    List<Notice> findTop2UnreadByUserId(@Param("userId") String userId, Pageable pageable);
+    List<Notice> findUnreadByUserId(@Param("userId") String userId, Pageable pageable);
 
 
 }

--- a/backend/src/main/java/com/shhtudy/backend/service/NoticeService.java
+++ b/backend/src/main/java/com/shhtudy/backend/service/NoticeService.java
@@ -84,7 +84,7 @@ public class NoticeService {
 
     @Transactional(readOnly = true)
     public List<NoticeSummaryResponseDto> getUnreadNoticeForMyPage(String firebaseUid) {
-        List<Notice> unreadNotices = noticeRepository.findTop2UnreadByUserId(
+        List<Notice> unreadNotices = noticeRepository.findUnreadByUserId(
                 firebaseUid,
                 PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"))
         );


### PR DESCRIPTION
## ✨ 요약
메서드 이름과 동작 간 불일치를 해결하기 위해 `findTop2UnreadByUserId`를 `findUnreadByUserId`로 리네이밍했습니다.

## ✅ 변경 내용
- `NoticeRepository` 메서드 이름 변경
- 서비스/컨트롤러 등 전체 호출부 반영
- 기능 동작에는 변화 없음
- 
## 🔎 관련 이슈
Closes #32 
