### PR TITLE
Backend/feat/53 report summary

### DIFF
--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/controller/NoiseController.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/controller/NoiseController.java
@@ -1,7 +1,9 @@
 package com.shhtudy.backend.domain.noise.controller;
 
 import com.shhtudy.backend.domain.noise.dto.NoiseEventRequestDto;
+import com.shhtudy.backend.domain.noise.dto.NoiseReportResponseDto;
 import com.shhtudy.backend.domain.noise.dto.NoiseSessionRequestDto;
+import com.shhtudy.backend.domain.noise.dto.MannerScoreResponseDto;
 import com.shhtudy.backend.domain.noise.service.NoiseService;
 import com.shhtudy.backend.global.response.ResponseCustom;
 import com.shhtudy.backend.domain.user.entity.User;
@@ -39,10 +41,15 @@ public class NoiseController {
         return ResponseCustom.OK("세션 종료 및 통계 저장 완료");
     }
 
-    @PutMapping("/score")
-    @Operation(summary = "점수 및 티어 계산", description = "인증된 사용자의 점수 및 등급을 다시 계산합니다.")
-    public ResponseCustom<Void> calculateScoreAndTier(@AuthenticationPrincipal User user) {
-        noiseService.recalculateUserScoreAndGrade(user);
-        return ResponseCustom.OK("점수 및 등급이 재계산되었습니다.");
+    @GetMapping("/report")
+    @Operation(summary = "소음 리포트 조회", description = "가장 최근 소음 세션의 통계 리포트를 조회합니다.")
+    public ResponseCustom<NoiseReportResponseDto> getReport(@AuthenticationPrincipal User user) {
+        return ResponseCustom.OK(noiseService.getNoiseReport(user));
+    }
+
+    @GetMapping("/manner")
+    @Operation(summary = "매너 점수 조회", description = "현재 사용자의 누적 포인트, 등급, 평균 데시벨, 소음 이벤트 횟수를 조회합니다.")
+    public ResponseCustom<MannerScoreResponseDto> getMannerScore(@AuthenticationPrincipal User user) {
+        return ResponseCustom.OK(noiseService.getMannerScore(user));
     }
 }

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/MannerScoreResponseDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/MannerScoreResponseDto.java
@@ -1,0 +1,23 @@
+package com.shhtudy.backend.domain.noise.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "매너 점수 응답 DTO")
+public class MannerScoreResponseDto {
+
+    @Schema(description = "사용자 포인트", example = "100")
+    private int point;
+
+    @Schema(description = "사용자 등급", example = "B")
+    private String grade;
+
+    @Schema(description = "평균 데시벨", example = "42.3")
+    private double avgDecibel;
+
+    @Schema(description = "기준 초과 횟수", example = "3")
+    private int eventCount;
+}

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/NoiseEventSummaryDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/NoiseEventSummaryDto.java
@@ -1,5 +1,6 @@
 package com.shhtudy.backend.domain.noise.dto;
 
+import com.shhtudy.backend.domain.noise.entity.NoiseEvent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +15,15 @@ public class NoiseEventSummaryDto {
     @Schema(description = "평균 데시벨", example = "55.0")
     private double decibel;
 
-    @Schema(description = "설명 메시지", example = "기준 소음 초과")
-    private String description;
-
     @Schema(description = "발생 시각", example = "2025-04-25T14:32:00")
     private LocalDateTime measuredAt;
+
+    // NoiseEvent → NoiseEventSummaryDto 변환
+    public static NoiseEventSummaryDto from(NoiseEvent event) {
+        return NoiseEventSummaryDto.builder()
+                .decibel(event.getDecibel())
+                .measuredAt(event.getMeasuredAt())
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/NoiseSessionRequestDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/NoiseSessionRequestDto.java
@@ -20,10 +20,12 @@ public class NoiseSessionRequestDto {
     @Schema(description = "체크아웃 시각", example = "2025-06-11T15:30:00")
     private LocalDateTime checkoutTime;
 
-    @NotNull
+    @Schema(description = "평균 데시벨", example = "42.3")
     private double averageDecibel;
-    @NotNull
+
+    @Schema(description = "조용한 시간 비율 (0.0 ~ 1.0)", example = "0.82")
     private double quietRatio;
-    @NotNull
+
+    @Schema(description = "최고 데시벨", example = "63.0")
     private double maxDecibel;
 }

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/NoiseSessionRequestDto.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/dto/NoiseSessionRequestDto.java
@@ -19,4 +19,11 @@ public class NoiseSessionRequestDto {
     @NotNull
     @Schema(description = "체크아웃 시각", example = "2025-06-11T15:30:00")
     private LocalDateTime checkoutTime;
+
+    @NotNull
+    private double averageDecibel;
+    @NotNull
+    private double quietRatio;
+    @NotNull
+    private double maxDecibel;
 }

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/entity/NoiseEvent.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/entity/NoiseEvent.java
@@ -1,5 +1,6 @@
 package com.shhtudy.backend.domain.noise.entity;
 
+import com.shhtudy.backend.domain.noise.dto.NoiseEventSummaryDto;
 import com.shhtudy.backend.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/repository/NoiseEventRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/repository/NoiseEventRepository.java
@@ -1,6 +1,7 @@
 package com.shhtudy.backend.domain.noise.repository;
 
 import com.shhtudy.backend.domain.noise.entity.NoiseEvent;
+import com.shhtudy.backend.domain.noise.entity.NoiseSession;
 import com.shhtudy.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,5 +13,7 @@ import java.util.List;
 public interface NoiseEventRepository extends JpaRepository<NoiseEvent, Long> {
 
     List<NoiseEvent> findByUserAndMeasuredAtBetween(User user, LocalDateTime start, LocalDateTime end);
+
+    List<NoiseEvent> findBySession(NoiseSession session);
 
 }

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/repository/NoiseSessionRepository.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/repository/NoiseSessionRepository.java
@@ -16,4 +16,6 @@ public interface NoiseSessionRepository extends JpaRepository<NoiseSession, Long
 
     // 아직 닫히지 않은 가장 최근 세션만 조회
     Optional<NoiseSession> findTopByUserAndCheckoutTimeIsNullOrderByCheckinTimeDesc(User user);
+
+    Optional<NoiseSession> findTopByUserAndCheckoutTimeIsNotNullOrderByCheckoutTimeDesc(User user);
 }

--- a/backend/src/main/java/com/shhtudy/backend/domain/noise/service/NoiseService.java
+++ b/backend/src/main/java/com/shhtudy/backend/domain/noise/service/NoiseService.java
@@ -1,7 +1,6 @@
 package com.shhtudy.backend.domain.noise.service;
 
-import com.shhtudy.backend.domain.noise.dto.NoiseEventRequestDto;
-import com.shhtudy.backend.domain.noise.dto.NoiseSessionRequestDto;
+import com.shhtudy.backend.domain.noise.dto.*;
 import com.shhtudy.backend.domain.noise.entity.NoiseEvent;
 import com.shhtudy.backend.domain.noise.entity.NoiseSession;
 import com.shhtudy.backend.domain.noise.repository.NoiseEventRepository;
@@ -12,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -23,8 +24,7 @@ public class NoiseService {
     private final UserRepository userRepository;
 
     private static final double QUIET_THRESHOLD_DB = 45.0;
-    private static final double SILENT_GRADE_THRESHOLD = 0.9;
-    private static final double GOOD_GRADE_THRESHOLD = 0.7;
+
     // 소음 이벤트 저장
     public void saveNoiseEvent(User user, NoiseEventRequestDto dto) {
         NoiseEvent event = NoiseEvent.builder()
@@ -32,87 +32,139 @@ public class NoiseService {
                 .decibel(dto.getDecibel())
                 .measuredAt(dto.getMeasuredAt())
                 .build();
-
         noiseEventRepository.save(event);
     }
 
-    // 세션 종료 및 통계 저장
+    // 세션 종료
     @Transactional
     public void closeSession(User user, NoiseSessionRequestDto dto) {
+        // 세션 조회
         NoiseSession session = noiseSessionRepository.findTopByUserAndCheckoutTimeIsNullOrderByCheckinTimeDesc(user)
                 .orElseThrow(() -> new IllegalArgumentException("진행 중인 세션이 없습니다."));
 
+        //로그 조회
         List<NoiseEvent> events = noiseEventRepository.findByUserAndMeasuredAtBetween(
                 user, dto.getCheckinTime(), dto.getCheckoutTime());
 
-        double avgDb = 0;
-        double maxDb = 0;
-        double quietRatio = 0;
+        int abruptCount = countAbruptNoises(events);
+        int sessionScore = calculateSessionScore(dto.getAverageDecibel(), dto.getQuietRatio(), abruptCount);
+        updateUserPointsAndGrade(user, sessionScore);
 
-        if (!events.isEmpty()) {
-            avgDb = events.stream().mapToDouble(NoiseEvent::getDecibel).average().orElse(0);
-            maxDb = events.stream().mapToDouble(NoiseEvent::getDecibel).max().orElse(0);
-            long quietCount = events.stream()
-                    .filter(e -> e.getDecibel() < QUIET_THRESHOLD_DB)
-                    .count();
-            quietRatio = (double) quietCount / events.size();
-        }
-
-        // 점수 및 등급 계산
-        calculateScoreAndTier(user, quietRatio);
-
-        // 세션 정보 저장
         session.setCheckoutTime(dto.getCheckoutTime());
-        session.setAvgDecibel(avgDb);
-        session.setMaxDecibel(maxDb);
-        session.setQuietRatio(quietRatio);
+        session.setAvgDecibel(dto.getAverageDecibel());
+        session.setMaxDecibel(dto.getMaxDecibel());
+        session.setQuietRatio(dto.getQuietRatio());
         noiseSessionRepository.save(session);
     }
 
-    // 점수 및 등급 계산: User의 points와 grade를 업데이트함
-    @Transactional
-    public void calculateScoreAndTier(User user, double quietRatio) {
-        int sessionPoints = (int) (quietRatio * 100.0);
-        user.setPoints(user.getPoints() + sessionPoints);
+    private int countAbruptNoises(List<NoiseEvent> events) {
+        List<NoiseEvent> sorted = events.stream()
+                .sorted(Comparator.comparing(NoiseEvent::getMeasuredAt))
+                .toList();
 
-        List<NoiseSession> sessions = noiseSessionRepository.findByUser(user);
-        double totalQuietRatio = sessions.stream().mapToDouble(NoiseSession::getQuietRatio).sum();
-        double averageQuietRatio = sessions.isEmpty()
-                ? quietRatio
-                : (totalQuietRatio + quietRatio) / (sessions.size() + 1);
+        int count = 0;
+        long consecutiveSeconds = 0;
+        NoiseEvent prev = null;
 
-        // 등급 설정
-        if (averageQuietRatio >= SILENT_GRADE_THRESHOLD) {
+        for (NoiseEvent event : sorted) {
+            if (event.getDecibel() > QUIET_THRESHOLD_DB) {
+                if (prev != null) {
+                    long diff = Duration.between(prev.getMeasuredAt(), event.getMeasuredAt()).getSeconds();
+                    if (diff <= 1) {
+                        consecutiveSeconds += diff;
+                    } else {
+                        consecutiveSeconds = 1;
+                    }
+                } else {
+                    consecutiveSeconds = 1;
+                }
+
+                if (consecutiveSeconds >= 3) {
+                    count++;
+                    consecutiveSeconds = 0;
+                    prev = null;
+                    continue;
+                }
+            } else {
+                consecutiveSeconds = 0;
+            }
+            prev = event;
+        }
+        return count;
+    }
+
+    private int calculateSessionScore(double avgDb, double quietRatio, int abruptCount) {
+        int score = 0;
+        score += (quietRatio >= 0.9) ? 5 : (quietRatio >= 0.7 ? 3 : 0);
+        score += (avgDb <= 40) ? 5 : (avgDb <= 50 ? 3 : 0);
+        score += (abruptCount == 0) ? 5 : (abruptCount <= 2 ? 3 : 0);
+        return Math.max(-15, Math.min(15, score));
+    }
+
+    private void updateUserPointsAndGrade(User user, int sessionScore) {
+        int currentPoints = user.getPoints();
+        int newPoints = Math.max(0, Math.min(300, currentPoints + sessionScore));
+        user.setPoints(newPoints);
+
+        if (newPoints >= 240) {
             user.setGrade(User.Grade.SILENT);
-        } else if (averageQuietRatio >= GOOD_GRADE_THRESHOLD) {
+        } else if (newPoints >= 160) {
             user.setGrade(User.Grade.GOOD);
         } else {
             user.setGrade(User.Grade.WARNING);
         }
-
-        // 수정된 사용자 정보 저장
         userRepository.save(user);
     }
 
-    @Transactional
-    public void recalculateUserScoreAndGrade(User user) {
-        List<NoiseSession> sessions = noiseSessionRepository.findByUser(user);
+    @Transactional(readOnly = true)
+    public NoiseReportResponseDto getNoiseReport(User user) {
+        // 가장 최근 종료된 세션 조회
+        NoiseSession session = noiseSessionRepository
+                .findTopByUserAndCheckoutTimeIsNotNullOrderByCheckoutTimeDesc(user)
+                .orElseThrow(() -> new IllegalArgumentException("종료된 세션이 없습니다."));
 
-        // 전체 조용 비율 평균 재계산
-        double averageQuietRatio = sessions.isEmpty()
-                ? 0.0
-                : sessions.stream().mapToDouble(NoiseSession::getQuietRatio).average().orElse(0);
+        // 해당 세션의 모든 소음 이벤트 가져오기
+        List<NoiseEvent> events = noiseEventRepository.findBySession(session);
 
-        // 등급 다시 지정
-        if (averageQuietRatio >= SILENT_GRADE_THRESHOLD) {
-            user.setGrade(User.Grade.SILENT);
-        } else if (averageQuietRatio >= GOOD_GRADE_THRESHOLD) {
-            user.setGrade(User.Grade.GOOD);
-        } else {
-            user.setGrade(User.Grade.WARNING);
-        }
+        // 통계 계산
+        double avgDecibel = session.getAvgDecibel();
+        double maxDecibel = session.getMaxDecibel();
+        int eventCount = (int) events.stream().filter(e -> e.getDecibel() > QUIET_THRESHOLD_DB).count();
+        double userQuietRatio = session.getQuietRatio();
 
-        userRepository.save(user); // 저장해줘야 반영됨
+        // 요약 소음 이벤트 3개 추출
+        List<NoiseEventSummaryDto> summaryDto = events.stream()
+                .filter(e -> e.getDecibel() > QUIET_THRESHOLD_DB)
+                .sorted(Comparator.comparing(NoiseEvent::getDecibel).reversed())
+                .limit(3)
+                .map(NoiseEventSummaryDto::from)
+                .toList();
+
+        // 리포트 DTO 생성
+        return NoiseReportResponseDto.builder()
+                .grade(user.getGrade().name())
+                .avgDecibel(avgDecibel)
+                .maxDecibel(maxDecibel)
+                .eventCount(eventCount)
+                .userQuietRatio(userQuietRatio)
+                .eventSummaries(summaryDto)
+                .build();
     }
 
+    @Transactional(readOnly = true)
+    public MannerScoreResponseDto getMannerScore(User user) {
+        List<NoiseSession> sessions = noiseSessionRepository.findByUser(user);
+
+        double averageDb = sessions.stream().mapToDouble(NoiseSession::getAvgDecibel).average().orElse(0.0);
+        int totalOverCount = (int) sessions.stream()
+                .mapToLong(s -> noiseEventRepository.findBySession(s).stream()
+                        .filter(e -> e.getDecibel() > QUIET_THRESHOLD_DB).count()).sum();
+
+        return MannerScoreResponseDto.builder()
+                .point(user.getPoints())
+                .grade(user.getGrade().name())
+                .avgDecibel(averageDb)
+                .eventCount(totalOverCount)
+                .build();
+    }
 }


### PR DESCRIPTION
## ✨ 요약
소음 레포트 조회 API
점수 계산 로직 수정

## ✅ 작업 내용
- [ ] API 구현
- [ ] 테스트 코드 작성
- [ ] 예외 처리 추가

## 📚 참고 자료
<!-- 관련 문서, 링크 등 -->

## 🔎 관련 이슈
Closes #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced endpoints for saving noise events, closing noise sessions, retrieving the latest noise session report, and fetching user manner score summaries.
  - Added a manner score summary feature, providing user points, grade, average decibel, and event count.
  - Users can now view detailed noise session reports, including statistics and top noise events.

- **Improvements**
  - Enhanced API request validation and documentation for noise event/session data.
  - Unified and improved API responses for consistency and clarity.

- **Bug Fixes**
  - Improved accuracy of session scoring and user grade assignment based on noise data.

- **Refactor**
  - Streamlined user authentication and request handling for all noise-related endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->